### PR TITLE
Removing onDelete('cascade')

### DIFF
--- a/database/migrations/2018_02_06_014318_create_sales_table.php
+++ b/database/migrations/2018_02_06_014318_create_sales_table.php
@@ -19,7 +19,7 @@ class CreateSalesTable extends Migration
             $table->integer('seller_id')->unsigned();
             $table->timestamps();
 
-            $table->foreign('seller_id')->references('id')->on('sellers')->onDelete('cascade');
+            $table->foreign('seller_id')->references('id')->on('sellers');
         });
     }
 


### PR DESCRIPTION
Removin onDelete('cascade') from sales-sellers relationship, because when the seller goes away, the sale remains.